### PR TITLE
merge(fix): support conditional compiles based on board & processor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,8 @@ target_link_libraries(mlem
     hardware_watchdog
     pico_multicore
     pico_rand
+    pico_atomic
+    pico_sync
     ${CMAKE_SOURCE_DIR}/zig-out/mlem.o
 )
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,26 @@ export PICO_SDK_PATH="path-to-possum-project/pico-sdk/"
 export PATH="path-to-arm-gnu-toolchain/bin/":$PATH
 ```
 
+Set the board and platform in `build.zig`
+```zig
+const Board = enum {
+    pico,
+    pico2_w,
+};
+const Platform = enum {
+    rp2040,
+    rp2350,
+};
+
+// example
+pub fn build(b: *std.Build) anyerror!void {
+    const board = Board.pico;
+    const platform = Platform.rp2040;
+
+    // snippet
+}
+```
+
 ### Using docker
 - build the image
 

--- a/build.zig
+++ b/build.zig
@@ -3,6 +3,8 @@ const builtin = @import("builtin");
 
 const Board = enum {
     pico,
+    pico_w,
+    pico2,
     pico2_w,
 };
 const Platform = enum {

--- a/build.zig
+++ b/build.zig
@@ -1,8 +1,14 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
-const Board = .pico;
-const Platform = .rp2040;
+const Board = enum {
+    pico,
+    pico2_w,
+};
+const Platform = enum {
+    rp2040,
+    rp2350,
+};
 
 const StdioUsb = true;
 const PicoStdlibDefine = if (StdioUsb) "LIB_PICO_STDIO_USB" else "LIB_PICO_STDIO_UART";
@@ -11,9 +17,17 @@ const PicoSDKPath: ?[]const u8 = null;
 const ARMNoneEabiPath: ?[]const u8 = null;
 
 pub fn build(b: *std.Build) anyerror!void {
+    const board = Board.pico;
+    const platform = Platform.rp2040;
+
+    const cpu_model = switch (platform) {
+        .rp2040 => &std.Target.arm.cpu.cortex_m0plus,
+        .rp2350 => &std.Target.arm.cpu.cortex_m33,
+    };
+
     const target_query = std.Target.Query{
         .abi = .eabi,
-        .cpu_model = .{ .explicit = &std.Target.arm.cpu.cortex_m0plus },
+        .cpu_model = .{ .explicit = cpu_model },
         .cpu_arch = .thumb,
         .os_tag = .freestanding,
     };
@@ -26,6 +40,13 @@ pub fn build(b: *std.Build) anyerror!void {
         .target = b.resolveTargetQuery(target_query),
         .optimize = optimize,
     });
+
+    const build_options = b.addOptions();
+    build_options.addOption(Platform, "platform", platform);
+    build_options.addOption(Board, "board", board);
+
+    lib.root_module.addOptions("config", build_options);
+
 
     const pico_sdk_path =
         if (PicoSDKPath) |sdk_path| sdk_path else std.process.getEnvVarOwned(b.allocator, "PICO_SDK_PATH") catch null orelse {
@@ -59,11 +80,11 @@ pub fn build(b: *std.Build) anyerror!void {
     lib.addSystemIncludePath(.{ .cwd_relative = arm_header_location });
 
     const board_header = blk: {
-        const header_file = @tagName(Board) ++ ".h";
+        const header_file = @tagName(board) ++ ".h";
         const _board_headers = b.pathJoin(&.{ pico_sdk_path, "src/boards/include/boards", header_file });
 
         std.fs.cwd().access(_board_headers, .{}) catch {
-            std.log.err("could not find header file for board {s}\n", .{@tagName(Board)});
+            std.log.err("could not find header file for board {s}\n", .{@tagName(board)});
             return;
         };
 
@@ -123,7 +144,6 @@ pub fn build(b: *std.Build) anyerror!void {
         "/src/rp2_common/pico_platform_sections/include",
         "/src/rp2_common/hardware_xip_cache/include",
         "/src/rp2_common/pico_aon_timer/include",
-        "/src/rp2_common/pico_fix/rp2040_usb_device_enumeration/include",
         "/src/rp2_common/pico_sha256/include",
         "/src/rp2_common/pico_cyw43_arch/include",
         "/src/rp2_common/hardware_boot_lock/include",
@@ -168,10 +188,6 @@ pub fn build(b: *std.Build) anyerror!void {
         "/src/rp2_common/pico_flash/include",
         "/src/rp2_common/hardware_flash/include",
         "/src/rp2_common/pico_stdio_usb/include",
-        "/src/rp2040/boot_stage2/include",
-        "/src/rp2040/hardware_regs/include",
-        "/src/rp2040/hardware_structs/include",
-        "/src/rp2040/pico_platform/include",
     };
 
     for (pico_sdk_includes) |path| {
@@ -181,12 +197,42 @@ pub fn build(b: *std.Build) anyerror!void {
         lib.addIncludePath(.{ .cwd_relative = include_path });
     }
 
+    const platform_includes = switch (platform) {
+        .rp2040 => &[_][]const u8 {
+            "/src/rp2_common/pico_fix/rp2040_usb_device_enumeration/include",
+            "/src/rp2040/boot_stage2/include",
+            "/src/rp2040/hardware_regs/include",
+            "/src/rp2040/hardware_structs/include",
+            "/src/rp2040/pico_platform/include",
+        },
+        .rp2350 => &[_][]const u8 {
+            "/src/rp2350/boot_stage2/include",
+            "/src/rp2350/hardware_regs/include",
+            "/src/rp2350/hardware_structs/include",
+            "/src/rp2350/pico_platform/include",
+        }
+    };
+
+    for (platform_includes) |path| {
+        const include_path = std.fs.path.join(b.allocator, &[_][]const u8{ pico_sdk_path, path }) catch return;
+        lib.addIncludePath(.{ .cwd_relative = include_path });
+    }
+
     // Platform Specific macros
-    lib.root_module.addCMacro("PICO_RP2040", "1");
     lib.root_module.addCMacro("PICO_32BIT", "1");
     lib.root_module.addCMacro("PICO_ARM", "1");
-    lib.root_module.addCMacro("PICO_CMSIS_DEVICE", "RP2040");
     lib.root_module.addCMacro("PICO_DEFAULT_FLASH_SIZE_BYTES", "\"2 * 1024 * 1024\"");
+
+    switch (platform) {
+        .rp2040 => {
+            lib.root_module.addCMacro("PICO_RP2040", "1");
+            lib.root_module.addCMacro("PICO_CMSIS_DEVICE", "RP2040");
+        },
+        .rp2350 => {
+            lib.root_module.addCMacro("PICO_RP2350", "1");
+            lib.root_module.addCMacro("PICO_CMSIS_DEVICE", "RP2350");
+        },
+    }
 
     // UART or USB
     lib.root_module.addCMacro(PicoStdlibDefine, "1");
@@ -234,8 +280,8 @@ pub fn build(b: *std.Build) anyerror!void {
         "-B",
         "./build",
         "-S .",
-        "-DPICO_BOARD=" ++ @tagName(Board),
-        "-DPICO_PLATFORM=" ++ @tagName(Platform),
+        "-DPICO_BOARD=" ++ @tagName(board),
+        "-DPICO_PLATFORM=" ++ @tagName(platform),
         cmake_pico_sdk_path,
         uart_or_usb,
     };

--- a/src/init.zig
+++ b/src/init.zig
@@ -1,3 +1,4 @@
+const config = @import("config");
 const p = @import("common/common.zig").p;
 const common = @import("common/common.zig");
 
@@ -6,32 +7,54 @@ const common = @import("common/common.zig");
 pub fn init() void {
     _ = p.stdio_init_all();
 
-    p.gpio_init(25);
-    p.gpio_set_dir(25, true);
-    p.sleep_ms(2000);
+    // p.gpio_init(25);
+    // p.gpio_set_dir(25, true);
+    // p.sleep_ms(2000);
 
-    for (0..10) |_| {
-        p.gpio_put(25, true);
-        p.sleep_ms(100);
-        p.gpio_put(25, false);
-        p.sleep_ms(100);
-    }
+    // for (0..10) |_| {
+    //     p.gpio_put(25, true);
+    //     p.sleep_ms(100);
+    //     p.gpio_put(25, false);
+    //     p.sleep_ms(100);
+    // }
 
     _ = p.printf("finished boot wait\n");
 
-    p.hw_set_bits(
-        @as(
-            [*c]p.io_rw_32, 
-            @ptrFromInt(p.PPB_BASE + p.M0PLUS_SHPR2_OFFSET)
-        ),
-        p.M0PLUS_SHPR2_BITS
-    );
+    switch (config.platform) {
+        .rp2350 => {
+            p.hw_set_bits(
+                @as(
+                    [*c]p.io_rw_32, 
+                    @ptrFromInt(p.PPB_BASE + p.M33_SHPR2_OFFSET)
+                ),
+                p.M33_SHPR2_BITS
+            );
 
-    p.hw_set_bits(
-        @as(
-            [*c]p.io_rw_32, 
-            @ptrFromInt(p.PPB_BASE + p.M0PLUS_SHPR3_OFFSET)
-        ),
-        p.M0PLUS_SHPR3_BITS
-    );
+            p.hw_set_bits(
+                @as(
+                    [*c]p.io_rw_32, 
+                    @ptrFromInt(p.PPB_BASE + p.M33_SHPR3_OFFSET)
+                ),
+                p.M33_SHPR3_BITS
+            );
+        },
+        .rp2040 => {
+            p.hw_set_bits(
+                @as(
+                    [*c]p.io_rw_32, 
+                    @ptrFromInt(p.PPB_BASE + p.M0PLUS_SHPR2_OFFSET)
+                ),
+                p.M0PLUS_SHPR2_BITS
+            );
+
+            p.hw_set_bits(
+                @as(
+                    [*c]p.io_rw_32, 
+                    @ptrFromInt(p.PPB_BASE + p.M0PLUS_SHPR3_OFFSET)
+                ),
+                p.M0PLUS_SHPR3_BITS
+            );
+        },
+    }
+
 }

--- a/src/init.zig
+++ b/src/init.zig
@@ -7,16 +7,18 @@ const common = @import("common/common.zig");
 pub fn init() void {
     _ = p.stdio_init_all();
 
-    // p.gpio_init(25);
-    // p.gpio_set_dir(25, true);
-    // p.sleep_ms(2000);
+    if (config.platform == .rp2040) {
+        p.gpio_init(25);
+        p.gpio_set_dir(25, true);
+        p.sleep_ms(2000);
 
-    // for (0..10) |_| {
-    //     p.gpio_put(25, true);
-    //     p.sleep_ms(100);
-    //     p.gpio_put(25, false);
-    //     p.sleep_ms(100);
-    // }
+        for (0..10) |_| {
+            p.gpio_put(25, true);
+            p.sleep_ms(100);
+            p.gpio_put(25, false);
+            p.sleep_ms(100);
+        }
+    }
 
     _ = p.printf("finished boot wait\n");
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -42,9 +42,9 @@ fn baz_task(ctx: *anyopaque) void {
     _ = ctx;
     while (true) {
         _ = p.printf("[BAZ TASK]\r\n");
-        p.gpio_put(25, true);
+        // p.gpio_put(25, true);
         p.sleep_ms(250);
-        p.gpio_put(25, false);
+        // p.gpio_put(25, false);
         p.sleep_ms(250);
     }
 }
@@ -67,8 +67,8 @@ export fn main() c_int {
 
     common.sched.lock();
     common.sched.init();
-    // common.sched.create_task(foo_task, null, 0, "abcdefgh".*);
-    // common.sched.create_task(bar_task, null, 0, "bar     ".*);
+    common.sched.create_task(foo_task, null, 0, "abcdefgh".*);
+    common.sched.create_task(bar_task, null, 0, "bar     ".*);
     common.sched.create_task(baz_task, null, 0, "baz     ".*);
     common.sched.unlock();
 

--- a/src/timer/timer.zig
+++ b/src/timer/timer.zig
@@ -1,3 +1,4 @@
+const config = @import("config");
 const p = @import("../common/common.zig").p;
 const common = @import("../common/common.zig");
 const addr = @import("../common/addrs.zig");
@@ -15,10 +16,21 @@ pub fn systick_config(n: c_ulong) void {
         \\ isb
     );
 
-    p.hw_set_bits(
-        @as([*c]p.io_rw_32, @ptrFromInt(p.PPB_BASE + p.M0PLUS_ICSR_OFFSET)), 
-        p.M0PLUS_ICSR_PENDSTCLR_BITS
-    );
+    switch (config.platform) {
+        .rp2350 => {
+            p.hw_set_bits(
+                @as([*c]p.io_rw_32, @ptrFromInt(p.PPB_BASE + p.M33_ICSR_OFFSET)), 
+                p.M33_ICSR_PENDSTCLR_BITS
+            );
+        },
+        .rp2040 => {
+            p.hw_set_bits(
+                @as([*c]p.io_rw_32, @ptrFromInt(p.PPB_BASE + p.M0PLUS_ICSR_OFFSET)), 
+                p.M0PLUS_ICSR_PENDSTCLR_BITS
+            );
+        }
+    }
+
 
     addr.SYST_RVR.* = n - 1;
     addr.SYST_CVR.* = 0;


### PR DESCRIPTION
**Reason for PR**
There are quite a bit of hard coded macro definitions used by CMake and the zig build system, along with the address associated per board (rp2040 and rp2350). Making any sort of change for compiling possum for a different pico board would require unnecessary modifications

**Solution**
Added build options along and enums for board types and board (`pico`, `pico_w`, `pico2`, `pico2_w`) and processor (`rp2040` and `rp2350`). These configs are available via an import.

```zig
const config = @import("config");

// platform sel available at config.platform
// board sel available at config.board
```

**Tests**
(trust me it works)